### PR TITLE
fixed_connection_in_web1

### DIFF
--- a/web1.tf
+++ b/web1.tf
@@ -11,6 +11,7 @@ resource "digitalocean_droplet" "web1" {
   connection {
     user = "root"
     type = "ssh"
+    host = digitalocean_droplet.web1.ipv4_address
     private_key = "${file(var.pvt_key)}"
     timeout = "2m"
   }


### PR DESCRIPTION
It seems the "connection" doesn't work without the 'host' parameter in Terraform version 0.11