### PR TITLE
Fixes erros and deprecations warnings

### DIFF
--- a/haproxy-web.tf
+++ b/haproxy-web.tf
@@ -1,17 +1,17 @@
 resource "digitalocean_droplet" "haproxy-web" {
     image = "ubuntu-16-04-x64"
     name = "haproxy-web"
-    region = "nyc2"
+    region = "nyc1"
     size = "512mb"
     private_networking = true
     ssh_keys = [
-      "${var.ssh_fingerprint}"
+      var.ssh_fingerprint
     ]
     connection {
-        host = "${digitalocean_droplet.haproxy-web}"
+        host = digitalocean_droplet.haproxy-web.ipv4_address
         user = "root"
         type = "ssh"
-        private_key = "${file(var.pvt_key)}"
+        private_key = file(var.pvt_key)
         timeout = "2m"
     }
     provisioner "remote-exec" {
@@ -22,7 +22,7 @@ resource "digitalocean_droplet" "haproxy-web" {
         ]
     }
     provisioner "file" {
-      content     = "${data.template_file.haproxyconf.rendered}"
+      content     = data.template_file.haproxyconf.rendered
       destination = "/etc/haproxy/haproxy.cfg"
     }
     provisioner "remote-exec" {

--- a/provider.tf
+++ b/provider.tf
@@ -1,3 +1,3 @@
 provider "digitalocean" {
-  token = "${var.do_token}"
+  token = var.do_token
 }

--- a/variables.tf
+++ b/variables.tf
@@ -1,23 +1,23 @@
 variable "do_token" {
-  type        = "string"
+  type        = string
   description = "Your DigitalOcean API token"
   default     = "ENTER VALUE"
 }
 
 variable "ssh_fingerprint" {
-  type        = "string"
+  type        = string
   description = "Your SSH key fingerprint"
   default     = "ENTER VALUE"
 }
 
 variable "pub_key" {
-  type        = "string"
+  type        = string
   description = "The path to your public SSH key"
   default     = "keys/dokey.pub"
 }
 
 variable "pvt_key" {
-  type        = "string"
+  type        = string
   description = "The path to your private SSH key"
   default     = "keys/dokey"
 }

--- a/web1.tf
+++ b/web1.tf
@@ -1,17 +1,17 @@
 resource "digitalocean_droplet" "web1" {
   image = "ubuntu-16-04-x64"
   name = "web1"
-  region = "nyc2"
+  region = "nyc1"
   size = "512mb"
   private_networking = true
-  user_data = "${file("config/webuserdata.sh")}"
+  user_data = file("config/webuserdata.sh")
   ssh_keys = [
-    "${var.ssh_fingerprint}"
+    var.ssh_fingerprint
   ]
   connection {
     user = "root"
     type = "ssh"
-    private_key = "${file(var.pvt_key)}"
+    private_key = file(var.pvt_key)
     timeout = "2m"
   }
 }

--- a/web2.tf
+++ b/web2.tf
@@ -1,17 +1,17 @@
 resource "digitalocean_droplet" "web2" {
   image = "ubuntu-16-04-x64"
   name = "web2"
-  region = "nyc2"
+  region = "nyc1"
   size = "512mb"
   private_networking = true
-  user_data = "${file("config/webuserdata.sh")}"
+  user_data = file("config/webuserdata.sh")
   ssh_keys = [
-    "${var.ssh_fingerprint}"
+    var.ssh_fingerprint
   ]
   connection {
     user = "root"
     type = "ssh"
-    private_key = "${file(var.pvt_key)}"
+    private_key = file(var.pvt_key)
     timeout = "2m"
   }
 }


### PR DESCRIPTION
Changes
  - region to nyc1

Fixes
  - 422 nyc2 is unavilable
  - Line 11 haproxy-web.tf: fails connection. Uses ipv4_address

Removes
  - Interpolation syntax for all non-constant expressions
    - removes warning: Interpolation-only expressions are deprecated
  - quotes from "string" in variable type defintion